### PR TITLE
`generate`および`generate_n`関数の修正

### DIFF
--- a/016-algorithm.md
+++ b/016-algorithm.md
@@ -1075,9 +1075,9 @@ auto generate = []( auto first, auto last, auto gen )
 
 auto generate_n = []( auto first, auto n, auto gen )
 {
-    for ( auto i = 0u ; i != n ; ++i, ++iter )
+    for ( auto i = 0u ; i != n ; ++i, ++first )
     {
-        *iter = gen() ;
+        *first = gen() ;
     }
 } ;
 ~~~

--- a/016-algorithm.md
+++ b/016-algorithm.md
@@ -1075,7 +1075,7 @@ auto generate = []( auto first, auto last, auto gen )
 
 auto generate_n = []( auto first, auto n, auto gen )
 {
-    for ( auto i = 0u ; i != n ; ++i, ++first )
+    for ( auto i = 0 ; i != n ; ++i, ++first )
     {
         *first = gen() ;
     }

--- a/016-algorithm.md
+++ b/016-algorithm.md
@@ -1065,7 +1065,7 @@ int main()
 実装例は単純だ。
 
 ~~~cpp
-auto generate = []( first, last, gen )
+auto generate = []( auto first, auto last, auto gen )
 {
     for ( auto iter = first ; iter != last ; ++iter )
     {
@@ -1073,7 +1073,7 @@ auto generate = []( first, last, gen )
     }
 } ;
 
-auto generate_n = []( first, n, gen )
+auto generate_n = []( auto first, auto n, auto gen )
 {
     for ( auto i = 0u ; i != n ; ++i, ++iter )
     {


### PR DESCRIPTION
- `generate` および `generate_n` のパラメータにautoを指定しました
- `generate_n` のタイプミスを修正しました: `iter` --> `first`
- `generate_n` のループ変数の初期化方法を`fill_n` と揃えました