### PR TITLE
`iota_iterator<T>`の修正

### DIFF
--- a/031-iterator-operations.md
+++ b/031-iterator-operations.md
@@ -893,6 +893,7 @@ struct iota_iterator
     // 要素の型
     using value_type = T ;
     using reference = T & ;
+    using const_reference = T const & ;
     using pointer = T * ;
     // イテレーターカテゴリーは前方イテレーター
     using iterator_category = std::forward_iterator_tag ;
@@ -931,7 +932,7 @@ int main()
 reference       operator *() noexcept
 { return value ; }
 // const版
-const reference operator *() const noexcept
+const_reference operator *() const noexcept
 { return value ; }
 ~~~
 

--- a/031-iterator-operations.md
+++ b/031-iterator-operations.md
@@ -949,7 +949,7 @@ int main()
     *non_const = 1 ;
 
     // constなオブジェクト
-    iota_iterator immutable(0) ;
+    const iota_iterator immutable(0) ;
     // const版のoperator *を呼び出す
     int const_value = *immutable ;
     // 変更はできない


### PR DESCRIPTION
const版の`operator *`について修正しました。