### PR TITLE
fix typo

### DIFF
--- a/035-copy.md
+++ b/035-copy.md
@@ -332,7 +332,7 @@ class own
     // その他のメンバー
 public :
     own( const own & ) = default ;
-    own & operator ==( const own & ) = default ;
+    own & operator = ( const own & ) = default ;
 }
 ~~~
 


### PR DESCRIPTION
コピー代入演算子の宣言であるので修正しました。