### PR TITLE
Add non-const operator* in cin_iterator

### DIFF
--- a/031-iterator-operations.md
+++ b/031-iterator-operations.md
@@ -651,6 +651,8 @@ struct cin_iterator
     { ++*this ; }    
 
     // キャッシュした値を返す
+    reference operator *()
+    { return value; }
     const reference operator *() const
     { return value ; }
 


### PR DESCRIPTION
## 変更点
31章（書籍版28.4.2）の `cin_operator` のコードに `const reference operator*() const` の `const` でない版を足した。

## 変更の理由
const付きのもののみの場合、書籍中のmain関数のサンプルコードを実行した場合以下のようなエラーを得たため。

```
cin_iterator.cpp: In instantiation of ‘T& cin_iterator<T>::operator*() const [with T = int; cin_iterator<T>::reference = int&]’:
/usr/include/c++/10/bits/stl_algobase.h:348:18:   required from ‘static _OI std::__copy_move<_IsMove, _IsSimple, _Category>::__copy_m(_II, _II, _OI) [with _II = cin_iterator<int>; _OI = std::back_insert_iterator<std::vector<int> >; bool _IsMove = false; bool _IsSimple = false; _Category = std::input_iterator_tag]’
/usr/include/c++/10/bits/stl_algobase.h:472:30:   required from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = cin_iterator<int>; _OI = std::back_insert_iterator<std::vector<int> >]’
/usr/include/c++/10/bits/stl_algobase.h:506:42:   required from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = cin_iterator<int>; _OI = std::back_insert_iterator<std::vector<int> >]’
/usr/include/c++/10/bits/stl_algobase.h:514:31:   required from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = cin_iterator<int>; _OI = std::back_insert_iterator<std::vector<int> >]’
/usr/include/c++/10/bits/stl_algobase.h:569:7:   required from ‘_OI std::copy(_II, _II, _OI) [with _II = cin_iterator<int>; _OI = std::back_insert_iterator<std::vector<int> >]’
cin_iterator.cpp:55:52:   required from here
cin_iterator.cpp:20:12: error: binding reference of type ‘cin_iterator<int>::reference’ {aka ‘int&’} to ‘const value_type’ {aka ‘const int’} discards qualifiers
   20 |     return value;
      |            ^~~~~
```