### PR TITLE
コピー代入コンストラクタのoperatorのtypo fix

### DIFF
--- a/035-copy.md
+++ b/035-copy.md
@@ -332,7 +332,7 @@ class own
     // その他のメンバー
 public :
     own( const own & ) = default ;
-    own & operator ==( const own & ) = default ;
+    own & operator =( const own & ) = default ;
 }
 ~~~
 
@@ -543,7 +543,7 @@ int main()
 
 ~~~cpp
 dynamic_array( const dynamic_array & r )
-    : first( new T[r.size()]), last( first + r.size() ) 
+    : first( new T[r.size()]), last( first + r.size() )
 {
     std::copy( r.begin(), r.end(), begin() ) ;
 }
@@ -715,7 +715,7 @@ vector & operator = ( const vector & r )
         std::copy( r.begin(), r.end(), begin() ) ;
     }
     // 3. それ以外の場合で
-    else 
+    else
         // 予約数が十分ならば、
         if ( capacity() >= r.size() )
         {


### PR DESCRIPTION
`operator==` -> `operator=`

## 再現コード

```cpp
#include "../all.h"

template <typename T>
class own
{
private:
  T * ptr;
public:
  own(): ptr(new T){}
  ~own(){ delete ptr; }

  T* get() const { return ptr; }

  own(const own &) = default;
  own & operator==(const own &) = default;
};

int main(){

}

```

### エラーメッセージ

```
$ g++ -std=c++20 -Wall -pedantic-errors own.cpp
own.cpp:15:9: error: defaulted ‘own<T>& own<T>::operator==(const own<T>&)’ must return ‘bool’
   15 |   own & operator==(const own &) = default;
      |         ^~~~~~~~
own.cpp:15:9: error: defaulted ‘own<T>& own<T>::operator==(const own<T>&)’ must be ‘const’
```
