### PR TITLE
22.2節の文脈を考慮した修正PR

### DIFF
--- a/022-implement-array.md
+++ b/022-implement-array.md
@@ -180,27 +180,28 @@ struct array_int_10
 配列はコピーできないが、クラスのデータメンバーとして宣言した配列は、クラスのコピーの際に、その対応する順番の要素がそれぞれコピーされる。
 
 ~~~cpp
-struct array_int_3 { int storage [3] ; } ;
+struct array_int_10 { int storage [10] ; } ;
 
 int main()
 {
-    array_int_3 a = { 0,1,2 } ;
+    array_int_10 a = {0,1,2,3,4,5,6,7,8,9} ;
 
-    array_int_3 b = a ;
+    array_int_10 b = a ;
     // b.storage[0] == a.storage[0] 
     // b.storage[1] == a.storage[1] 
     // b.storage[2] == a.storage[2] 
+    // ...
 }
 ~~~
 
 これはあたかも以下のように書いたかのように動く。
 
 ~~~cpp
-struct array_int_3
+struct array_int_10
 {
-    int storage[3] ;
+    int storage[10] ;
 
-    array_int_3( array_int_3 const & other )
+    array_int_10( array_int_10 const & other )
     {
         std::copy(
             std::begin(other.storage), std::end(other.storage),

--- a/022-implement-array.md
+++ b/022-implement-array.md
@@ -229,7 +229,7 @@ int main()
 {
     array_int_10 a = {0,1,2,3,4,5,6,7,8,9} ;
     a[3] = 0 ;
-    std::cout << a[6] ;
+    std::cout << a[3] ;
 }
 ~~~
 


### PR DESCRIPTION
### コミット 9545292bae80b0baa364adda14225dfb96b3c9bc

以下の文章以降で`array_int_3`を使用している箇所を`array_int_10`に修正しました。

https://github.com/EzoeRyou/cpp-intro/blob/276be36f7db41114b51c87a2a4bb618714e859c4/022-implement-array.md?plain=1#L169


### コミット 6aaf4e6ad3c76f3a9ebfeaf72e265c11e870956c

以下は、リファレンスの返りをつかい値変更が可能であることを示すことを意図されていると思うので、`a[6]`を`a[3]`に修正しました。

https://github.com/EzoeRyou/cpp-intro/blob/276be36f7db41114b51c87a2a4bb618714e859c4/022-implement-array.md?plain=1#L229-L231